### PR TITLE
docs(contributing): use action verbs for all PR types including docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -231,6 +231,16 @@ _"What am I building?"_
    Correct: "Gracefully recover from connection errors"
 1. **Use user action verbs**: _View, Play, Customize, Save_, etc.
 
+> [!WARNING]
+> This rule applies to **all PR types**, including `docs`. Do not use verbs that
+> describe what you did ("document", "update", "add") — use verbs that describe
+> what users can now do.
+>
+> | **Good** ✅                                        | **Bad** ❌                                          |
+> | -------------------------------------------------- | --------------------------------------------------- |
+> | `docs(typefully): log in with shared account`      | `docs(typefully): document shared account`          |
+> | `docs(api): authenticate with OAuth`               | `docs(api): add OAuth section to README`            |
+
 #### Before Submitting, Ask
 
 1. Does it use `type(scope [Optional]): action` format?


### PR DESCRIPTION
## Summary

The naming convention required user-focused action verbs, but this was only illustrated with `feat`/`fix`/`test` examples. The single `docs` example (`docs(ui): design table component`) used a developer-action verb ("design"), which contradicted the rule and made it easy to default to verbs like "document", "update", or "add".

Added an explicit warning after the user action verbs list clarifying the rule applies to all PR types, with a `docs` counterexample table.