### PR TITLE
feat: contribute to Holdex repos using a structured Claude Code skill

### DIFF
--- a/.claude/commands/holdex-contributing.md
+++ b/.claude/commands/holdex-contributing.md
@@ -1,0 +1,36 @@
+---
+name: holdex-contributing
+description: Holdex contributing rules for GitHub issues and PRs. Invoke before creating or updating issues or PRs in any Holdex repository.
+---
+
+All PRs and issues must follow the
+[Holdex Contributing Guidelines](https://github.com/holdex/developers/blob/main/docs/CONTRIBUTING.md).
+
+## Issues
+
+- Name: `Problem: [statement]` — must be a **job story** describing what a
+  specific user **cannot do** (the whole title under 65 characters).
+  - Good: `employees can't safely handle fund disbursements`
+  - Bad: `fund handling issue`
+- Link each Problem as a **sub-issue** of its parent Goal issue.
+- When referencing other issues or PRs, always use a **list item**, never inline:
+
+  ```md
+  - https://github.com/holdex/hr-internal/issues/123
+  ```
+
+## Pull Requests
+
+- **Title**: `type(scope): action` — user-focused, present tense, Conventional
+  Commits format.
+  - Good: `docs: protect client funds from unauthorized contractor custody`
+  - Bad: `Add FUND_HANDLING.md`
+- **Scope**: fits within 3–4 hours of work. Decompose if larger.
+- **Lifecycle** (in order):
+  1. Open as a **draft PR** immediately when starting work.
+  1. Link to the Problem issue using a closing keyword (`Closes #123`).
+  1. Assign yourself.
+  1. Resolve all CI checks.
+  1. Assign at least one reviewer.
+  1. Mark ready for review only when all steps above are done.
+- **Do not merge** without an approved review.

--- a/.claude/commands/holdex-contributing.md
+++ b/.claude/commands/holdex-contributing.md
@@ -13,10 +13,11 @@ All PRs and issues must follow the
   - Good: `employees can't safely handle fund disbursements`
   - Bad: `fund handling issue`
 - Link each Problem as a **sub-issue** of its parent Goal issue.
-- When referencing other issues or PRs, always use a **list item**, never inline:
+- When referencing other issues or PRs, always use a **list item**, never
+  inline:
 
   ```md
-  - https://github.com/holdex/hr-internal/issues/123
+  - <https://github.com/holdex/hr-internal/issues/123>
   ```
 
 ## Pull Requests

--- a/README.md
+++ b/README.md
@@ -24,8 +24,14 @@ improvements.
 
 ## Claude Code Skills
 
-Clone this repository locally to get access to shared Claude Code slash
-commands. Available skills:
+Clone this repository locally and symlink the commands directory to make all
+skills available globally across every repo you work in:
+
+```bash
+ln -s /path/to/holdex/developers/.claude/commands ~/.claude/commands
+```
+
+Skills stay up to date automatically as you pull the repo. Available skills:
 
 | Command | When to use |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ Align with:
 
 Subscribe to repository notifications to stay updated with frequent fixes and
 improvements.
+
+## Claude Code Skills
+
+Clone this repository locally to get access to shared Claude Code slash
+commands. Available skills:
+
+| Command | When to use |
+| --- | --- |
+| `/holdex-contributing` | Before creating or updating a GitHub issue or PR in any Holdex repository |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -54,8 +54,8 @@ As soon as you get involved, you must:
 
 ### Problem
 
-Once a Goal is clear, identify what prevents its achievement. Anything that
-acts as a barrier is a Problem.
+Once a Goal is clear, identify what prevents its achievement. Anything that acts
+as a barrier is a Problem.
 
 > [!NOTE]
 > Report each Problem as a [GitHub Issue](https://docs.github.com/en/issues)
@@ -103,8 +103,8 @@ For reimbursable work-related costs, see [Expenses](./EXPENSES.md).
 A Spec describes the intended behavior for a Goal — not what currently exists,
 but what the Goal aims to deliver. It is a markdown file in `docs/specs/`.
 
-A Google Document may be used for ideation before the Spec is written.
-If one exists, link it in the Goal issue description, not in the Spec.
+A Google Document may be used for ideation before the Spec is written. If one
+exists, link it in the Goal issue description, not in the Spec.
 
 A Goal must not be opened without a linked Spec.
 
@@ -229,8 +229,8 @@ Before marking your PR as ready for review, confirm:
 
 ### Commit Signature Verification
 
-All commits must be signed. See [GitHub's documentation on commit signature
-verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
+All commits must be signed. See
+[GitHub's documentation on commit signature verification](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification).
 
 > [!NOTE]
 > We recommend signing commits using an
@@ -283,9 +283,9 @@ PR names must be:
 | `fix(sdk): mute sound` | `Fix: add file to mute sound`  | Technical details  |
 | `test(api): open door` | `Feat: modified door function` | Vague, past tense  |
 
-A feature isn't a button, toggle, or handler — it's what the user gains from
-it. Ask _"What will users be able to do?"_ not _"What am I building?"_ Use
-action verbs: _View, Play, Customize, Save_.
+A feature isn't a button, toggle, or handler — it's what the user gains from it.
+Ask _"What will users be able to do?"_ not _"What am I building?"_ Use action
+verbs: _View, Play, Customize, Save_.
 
 > [!WARNING]
 > This rule applies to **all PR types**, including `docs`. Do not use verbs that

--- a/docs/LEAVE_POLICY.md
+++ b/docs/LEAVE_POLICY.md
@@ -23,8 +23,8 @@ These days cover **everything**: vacation, personal days, sick days, and public
 holidays. Default values above apply unless your individual agreement specifies
 otherwise.
 
-> These are your **annual entitlements** — days are not granted all at once.
-> See [How Do You Earn Days?](#how-do-you-earn-days-accrual) below for how they
+> These are your **annual entitlements** — days are not granted all at once. See
+> [How Do You Earn Days?](#how-do-you-earn-days-accrual) below for how they
 > accrue over the year.
 
 ## How Do You Earn Days? (Accrual)
@@ -32,7 +32,7 @@ otherwise.
 Days are **accrued gradually** throughout your leave year — you do not receive
 the full entitlement up front. The formula is:
 
-```
+```text
 paidLeaveAmount = (totalEligibleLeaves / 365) × daysElapsed
 ```
 


### PR DESCRIPTION
## Summary

- Adds `.claude/commands/holdex-contributing.md` — a `/holdex-contributing` skill for Claude Code
- Encodes the key rules from `CONTRIBUTING.md` (issue naming, PR title format, PR lifecycle) so contributors can invoke it on demand before creating or updating issues and PRs
- Available to any contributor who has this repo cloned locally

## Usage

Run `/holdex-contributing` in Claude Code before creating or updating a GitHub issue or PR in any Holdex repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Holdex-specific contribution guidelines detailing required formatting and lifecycle steps for Issues and Pull Requests (title formats, linking, draft/opening, assignment, CI/review requirements, and merge prohibition without approval)
  * Updated README to document how to access these contribution guidelines via the project's command/skill and include brief setup instructions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->