### PR TITLE
docs(contributing): write problem titles as user inabilities, not solutions

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -77,11 +77,15 @@ The statement must be a **job story** — describe what a specific user
 **cannot do** or what is broken for them. Ask:
 _"What can [user] not do because of this problem?"_
 
+If your title contains words like "automate", "build system", or "create process", it is describing a solution, not a problem. Replace it with the user inability that makes that solution necessary.
+
 | **Good** ✅                                    | **Bad** ❌                                   | **Why?**                       |
 | ---------------------------------------------- | -------------------------------------------- | ------------------------------ |
 | `operators can't view their account balance`   | `operators don't have their account balance` | Describes inability, not state |
 | `users can't submit a form without refreshing` | `form submission issue`                      | Vague, no actor or action      |
 | `admins can't export reports as CSV`           | `CSV export missing`                         | No subject, not a job story    |
+
+If you identify multiple distinct problems, open a separate issue for each. Do not combine them in a single issue.
 
 Ensure each Problem issue is properly interlinked with its parent Goal issue:
 


### PR DESCRIPTION
Two additions to the Problem naming guidelines, based on a recurring pattern observed in practice:

- Flags solution-oriented language (e.g. "automate", "build system", "create process") as a sign the title describes a fix rather than a problem, and instructs contributors to replace it with the user inability
- Requires separate issues when multiple distinct problems are identified

## Related

- https://github.com/holdex/marketing/issues/725

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to improve the quality of problem statements. Added new rules specifying that titles containing solution-oriented or process-related language should be rewritten to emphasize user needs and actual problems, and that multiple distinct issues must be submitted as separate contributions instead of being combined into a single problem statement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->