### PR TITLE
docs(contributing): keep docs interlinked and DRY

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -203,6 +203,10 @@ When introducing functional changes, cross-check the README and update it in the
 same PR. If your change affects anything documented there — setup steps,
 environment requirements, file references — the README must stay in sync.
 
+When adding new documentation files, ensure they are reachable via interlinking from the root entry point. Do not create orphaned files.
+
+Do not duplicate content across files. Each piece of information — procedures, templates, configuration steps — must live in exactly one place. Reference it from other docs rather than copying it.
+
 ### Naming
 
 > [!NOTE]

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -187,7 +187,8 @@ For detailed instructions on why and how to sign your commits refer to
 ### Scoping
 
 > [!TIP]
-> Here's a [good resource](https://youtu.be/bmSAYlu0NcY?si=2lLQeY1PGCY9tcvX) on software design philosophy.
+> Here's a [good resource](https://youtu.be/bmSAYlu0NcY?si=2lLQeY1PGCY9tcvX) on
+> software design philosophy.
 
 When planning the scope of work, make sure you
 [keep PRs small](https://artsy.github.io/blog/2021/03/09/strategies-for-small-focused-pull-requests/).
@@ -203,9 +204,12 @@ When introducing functional changes, cross-check the README and update it in the
 same PR. If your change affects anything documented there — setup steps,
 environment requirements, file references — the README must stay in sync.
 
-When adding new documentation files, ensure they are reachable via interlinking from the root entry point. Do not create orphaned files.
+When adding new documentation files, ensure they are reachable via interlinking
+from the root entry point. Do not create orphaned files.
 
-Do not duplicate content across files. Each piece of information — procedures, templates, configuration steps — must live in exactly one place. Reference it from other docs rather than copying it.
+Do not duplicate content across files. Each piece of information — procedures,
+templates, configuration steps — must live in exactly one place. Reference it
+from other docs rather than copying it.
 
 ### Naming
 
@@ -254,7 +258,8 @@ _"What am I building?"_
 
 #### Design PRs
 
-Design PRs use `docs(ui)` as the type and scope. e.g.: `docs(ui): design table component`
+Design PRs use `docs(ui)` as the type and scope. e.g.:
+`docs(ui): design table component`
 
 Initiate a PR with a note in the DESIGN.md file detailing the addressed design
 aspects. Structure the design file with the following markup:
@@ -286,7 +291,8 @@ Example:
       - [[Bid Popup]](https://figma.com/your-design-file-url)
 ```
 
-If there isn't an existing DESIGN.md file, create one and link it from README.md.
+If there isn't an existing DESIGN.md file, create one and link it from
+README.md.
 
 ### PR Lifecycle
 

--- a/docs/REFERRAL.md
+++ b/docs/REFERRAL.md
@@ -14,6 +14,6 @@ Once the eligibility conditions are met, reach out to your lead to claim the
 reward.
 
 > [!IMPORTANT]
-> This referral program applies unless there is a separate commercial
-> engagement between Holdex and the contributor, in which case referral terms
-> are governed by that agreement instead.
+> This referral program applies unless there is a separate commercial engagement
+> between Holdex and the contributor, in which case referral terms are governed
+> by that agreement instead.

--- a/docs/TRIAL.md
+++ b/docs/TRIAL.md
@@ -59,7 +59,8 @@ trial and follow our team's principles.
 
 ## I don't have access to open a PR in the repository. What do I do?
 
-Fork the repository and create a PR using a [Fork Strategy](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
+Fork the repository and create a PR using a
+[Fork Strategy](https://gist.github.com/Chaser324/ce0505fbed06b947d962).
 
 ## What is the trial duration?
 


### PR DESCRIPTION
Two additions to the Scoping section, based on a recurring documentation fragmentation pattern:

- New doc files must be reachable via interlinking from the root entry point — no orphaned files
- Content must live in exactly one place; other docs reference it rather than copying it

## Related

- https://github.com/holdex/marketing/issues/795

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to require new documentation be discoverable through root-level interlinking and to prevent orphaned pages within the documentation structure.
  * Added requirement that documentation content must not be duplicated across multiple files; instead, content should be referenced from other documentation files to maintain consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->