### PR TITLE
docs: claim reimbursable expenses via HR repo issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Align with:
 - [Leave Policy](./docs/LEAVE_POLICY.md)
 - [Compensation Guide](./docs/COMPENSATION.md)
 - [Referral Program](./docs/REFERRAL.md)
+- [Expenses](./docs/EXPENSES.md)
 
 Subscribe to repository notifications to stay updated with frequent fixes and
 improvements.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -102,6 +102,8 @@ solution from the contributor.
 > [Pull Request (PR)](https://docs.github.com/en/pull-requests) in compliance
 > with [PR Requirements](#pr-requirements).
 
+For reimbursable work-related costs, see [Expenses](./EXPENSES.md).
+
 ## Communication Guidelines
 
 ### Discussion channels

--- a/docs/EXPENSES.md
+++ b/docs/EXPENSES.md
@@ -7,20 +7,20 @@ reimbursed. Approval must be obtained **before** incurring the expense.
 
 1. Open an issue in your private HR repository (`holdex/hr-member-*`) with the
    title: `Expense: [brief description]`
-2. Include in the issue body:
+1. Include in the issue body:
    - What the expense is and why it is needed
    - Estimated amount (USD)
    - Link to the service or product
-3. Assign your manager to the issue.
-4. Wait for written approval in the issue thread before proceeding.
+1. Assign your manager to the issue.
+1. Wait for written approval in the issue thread before proceeding.
 
 ## After the expense is incurred
 
 Once approved and paid:
 
 1. Attach the receipt as a comment on the same issue.
-2. The expense will be included in your next monthly payout.
-3. Your manager will confirm reimbursement by commenting on the issue.
+1. The expense will be included in your next monthly payout.
+1. Your manager will confirm reimbursement by commenting on the issue.
 
 ## What qualifies
 

--- a/docs/EXPENSES.md
+++ b/docs/EXPENSES.md
@@ -1,0 +1,31 @@
+# Expenses
+
+Any pre-approved, reasonable expense tied to your work at Holdex can be
+reimbursed. Approval must be obtained **before** incurring the expense.
+
+## How to request pre-approval
+
+1. Open an issue in your private HR repository (`holdex/hr-member-*`) with the
+   title: `Expense: [brief description]`
+2. Include in the issue body:
+   - What the expense is and why it is needed
+   - Estimated amount (USD)
+   - Link to the service or product
+3. Assign your manager to the issue.
+4. Wait for written approval in the issue thread before proceeding.
+
+## After the expense is incurred
+
+Once approved and paid:
+
+1. Attach the receipt as a comment on the same issue.
+2. The expense will be included in your next monthly payout.
+3. Your manager will confirm reimbursement by commenting on the issue.
+
+## What qualifies
+
+Examples of reimbursable expenses: software subscriptions, infrastructure costs,
+travel, conference fees, lodging — when directly tied to your work at Holdex and
+pre-approved by your manager.
+
+Expenses incurred without prior written approval will not be reimbursed.


### PR DESCRIPTION
## Summary

- Adds `docs/EXPENSES.md` with the full expense claiming procedure: pre-approval required, issue format, receipt submission, payout timing
- References `EXPENSES.md` from `CONTRIBUTING.md` after the Solution section so all contributors can find it

## Related to

- https://github.com/holdex/hr-internal/pull/793

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to reference the expense reimbursement process
  * Added comprehensive documentation outlining the expense reimbursement policy, including submission requirements, approved expense categories, and reimbursement timeline

<!-- end of auto-generated comment: release notes by coderabbit.ai -->