### PR TITLE
docs: enforce 65-character limit on PR titles

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -224,7 +224,7 @@ PR names must be:
 1. **User-focused**: Describe what users gain, not technical implementation
 1. **Follow [Conventional Commits](https://www.conventionalcommits.org)**
 1. **Clear & simple** (present tense, action-oriented)
-1. **Up to 65 characters**
+1. **Under 65 characters**
 
 | **Good Examples** ✅   | **Bad Examples** ❌            | **Why?**           |
 | ---------------------- | ------------------------------ | ------------------ |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -258,7 +258,7 @@ _"What am I building?"_
 1. Could a non-technical user understand the benefit?
 1. Is it in the present tense?
 1. Does it focus on user capability (not code)?
-1. Is it under 65 characters?
+1. Is it up to 65 characters?
 
 #### Design PRs
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -224,7 +224,7 @@ PR names must be:
 1. **User-focused**: Describe what users gain, not technical implementation
 1. **Follow [Conventional Commits](https://www.conventionalcommits.org)**
 1. **Clear & simple** (present tense, action-oriented)
-1. **Under 65 characters**
+1. **Up to 65 characters**
 
 | **Good Examples** ✅   | **Bad Examples** ❌            | **Why?**           |
 | ---------------------- | ------------------------------ | ------------------ |

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -258,7 +258,7 @@ _"What am I building?"_
 1. Could a non-technical user understand the benefit?
 1. Is it in the present tense?
 1. Does it focus on user capability (not code)?
-1. Is it up to 65 characters?
+1. Is it under 65 characters?
 
 #### Design PRs
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -224,6 +224,7 @@ PR names must be:
 1. **User-focused**: Describe what users gain, not technical implementation
 1. **Follow [Conventional Commits](https://www.conventionalcommits.org)**
 1. **Clear & simple** (present tense, action-oriented)
+1. **Under 65 characters**
 
 | **Good Examples** ✅   | **Bad Examples** ❌            | **Why?**           |
 | ---------------------- | ------------------------------ | ------------------ |
@@ -257,6 +258,7 @@ _"What am I building?"_
 1. Could a non-technical user understand the benefit?
 1. Is it in the present tense?
 1. Does it focus on user capability (not code)?
+1. Is it under 65 characters?
 
 #### Design PRs
 


### PR DESCRIPTION
## Summary

- Adds a 65-character limit to the PR Naming requirements (already enforced by the wizard bot but not documented)
- Adds the length check to the "Before Submitting, Ask" checklist

The limit already exists for Problem issues in the Problem section. This aligns PR titles with the same rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Contribution guidelines now require PR titles to be limited to 65 characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->