### PR TITLE
docs(expenses): link expense to payout issue

### DIFF
--- a/docs/EXPENSES.md
+++ b/docs/EXPENSES.md
@@ -11,6 +11,7 @@ reimbursed. Approval must be obtained **before** incurring the expense.
    - What the expense is and why it is needed
    - Estimated amount (USD)
    - Link to the service or product
+1. Add it as a sub-issue of your dedicated payout issue.
 1. Assign your manager to the issue.
 1. Wait for written approval in the issue thread before proceeding.
 


### PR DESCRIPTION
## Summary

- Adds a step instructing members to add their expense approval issue as a sub-issue of their dedicated payout issue
- This makes the payout issue the single parent for all payment-related items (salary + expenses) per member
- Aligns with the verification step in holdex/hr-internal SALARY_PAYOUT.md