### PR TITLE
docs(contributing): require solution in problem issues

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -89,6 +89,19 @@ Ensure each Problem issue is properly interlinked with its parent Goal issue:
   feature.
 - Add the Goal issue link to the Problem description.
 
+Every Problem issue body must include both a `# Problem` and a `# Solution`
+section, describing the recommended approach or workaround before work begins.
+
+```md
+# Problem
+
+Describe what the user cannot do and why it matters.
+
+# Solution
+
+Describe the recommended approach or workaround.
+```
+
 ### Solution
 
 The third pillar of successful contribution is the Solution.

--- a/docs/EXPENSES.md
+++ b/docs/EXPENSES.md
@@ -11,6 +11,7 @@ reimbursed. Approval must be obtained **before** incurring the expense.
    - What the expense is and why it is needed
    - Estimated amount (USD)
    - Link to the service or product
+1. Add it as a sub-issue of your dedicated payout issue.
 1. Assign your manager to the issue.
 1. Wait for written approval in the issue thread before proceeding.
 


### PR DESCRIPTION
## Summary

- Extends the Problem issue guidelines in CONTRIBUTING.md to require a `# Solution` section in every Problem issue body
- Adds a template example showing the expected `# Problem` / `# Solution` structure

## References

- https://github.com/holdex/hr-internal/issues/814