### PR TITLE
feat(command): submit PR time via @holdex bot

### DIFF
--- a/.claude/commands/submit-time.md
+++ b/.claude/commands/submit-time.md
@@ -21,7 +21,7 @@ If no PR is found for the current branch, ask the user for the PR number or URL.
 ## Post the comment
 
 ```bash
-gh pr comment <number> --repo <owner/repo> --body "@holdex pr submit-time $ARGUMENTS"
+gh pr comment <PR_URL> --body "@holdex pr submit-time $ARGUMENTS"
 ```
 
 Confirm the comment was posted and show the PR URL.

--- a/.claude/commands/submit-time.md
+++ b/.claude/commands/submit-time.md
@@ -1,0 +1,27 @@
+Post a `@holdex pr submit-time` comment on a pull request to record time spent.
+
+## Input
+
+Time is provided as `$ARGUMENTS` (e.g. `2h30m`, `1h`, `45m`, `1.5h`).
+
+If `$ARGUMENTS` is empty, ask the user for the time before proceeding.
+
+Validate the format — accepted patterns: `15m`, `1h`, `2h30m`, `1.5h`. If the format is invalid, tell the user and stop.
+
+## Resolve the PR
+
+Detect the current PR from the git worktree:
+
+```bash
+gh pr list --head "$(git branch --show-current)" --json number,url,title --limit 1
+```
+
+If no PR is found for the current branch, ask the user for the PR number or URL.
+
+## Post the comment
+
+```bash
+gh pr comment <number> --repo <owner/repo> --body "@holdex pr submit-time $ARGUMENTS"
+```
+
+Confirm the comment was posted and show the PR URL.


### PR DESCRIPTION
Adds a global `/submit-time` Claude Code command that posts `@holdex pr submit-time <time>` on the current PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added user instructions for the submit-time command: how to provide time arguments (accepted formats like 15m, 1h, 2h30m, 1.5h), prompting/validation behavior, how the target pull request is resolved when not explicit, and confirmation that a time-posting comment is posted with the PR link.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/holdex/developers/pull/113)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->