### PR TITLE
docs(skill): distinguish submit-time from add-time in PR lifecycle

### DIFF
--- a/.claude/commands/submit-time.md
+++ b/.claude/commands/submit-time.md
@@ -1,12 +1,22 @@
-Post a `@holdex pr submit-time` comment on a pull request to record time spent.
+Post a `@holdex pr submit-time` or `@holdex pr add-time` comment on a pull request to record time spent.
 
 ## Input
 
-Time is provided as `$ARGUMENTS` (e.g. `2h30m`, `1h`, `45m`, `1.5h`).
+Time is provided as `$ARGUMENTS` (e.g. `2h30m`, `1h`, `45m`, `1.5h`), optionally
+prefixed with `add` to add time on top of a previous submission instead of
+replacing it (e.g. `add 1h30m`).
 
 If `$ARGUMENTS` is empty, ask the user for the time before proceeding.
 
-Validate the format — accepted patterns: `15m`, `1h`, `2h30m`, `1.5h`. If the format is invalid, tell the user and stop.
+Determine which mode applies:
+
+- No `add` prefix: **submit/update total time** — replaces any previously
+  recorded time for this PR with the given value.
+- `add` prefix: **add time on top of the previous submission** — strip the
+  `add` prefix to get the time value.
+
+Validate the time format — accepted patterns: `15m`, `1h`, `2h30m`, `1.5h`. If
+the format is invalid, tell the user and stop.
 
 ## Resolve the PR
 
@@ -20,8 +30,16 @@ If no PR is found for the current branch, ask the user for the PR number or URL.
 
 ## Post the comment
 
+Submit or update total time:
+
 ```bash
-gh pr comment <PR_URL> --body "@holdex pr submit-time $ARGUMENTS"
+gh pr comment <PR_URL> --body "@holdex pr submit-time <TIME>"
+```
+
+Add time on top of the previous submission:
+
+```bash
+gh pr comment <PR_URL> --body "@holdex pr add-time <TIME>"
 ```
 
 Confirm the comment was posted and show the PR URL.


### PR DESCRIPTION
## Summary
- Teach the /submit-time command both Wizard bot forms: \`pr submit-time <duration>\` (overwrite total) vs \`pr add-time <duration>\` (add on top of a previous submission)

## Context
The /submit-time command posted the wrong syntax on a PR because it only knew about \`pr submit-time\`, not the separate \`pr add-time\` command.

- Closes #120

## Test plan
- [ ] Confirm the command's accepted syntax matches the Wizard bot's actual behavior