### PR TITLE
docs(rules): judge work by value delivered, not effort spent

### DIFF
--- a/docs/rules/DEV-440.md
+++ b/docs/rules/DEV-440.md
@@ -1,0 +1,36 @@
+---
+id: DEV-440
+title: "Judge Work by Value Delivered, Not Effort Spent"
+status: "active"
+enforcement: "manual"
+severity: "error"
+depends_on: ["DEV-370"]
+---
+
+## Problem
+
+Work gets justified by the hours it took, so mechanical tasks a tool does in
+minutes still bill full cost, and effort stands in for value.
+
+## Solution
+
+Measure a change by the value it delivers against what it cost to produce, not
+by the time it took. High effort on low-value work is waste, not merit.
+
+1. Before spending hours on a task, ask whether the output justifies the cost.
+   A day designing a valuable solution is fine; hours porting a file between
+   formats or fighting a linter are not.
+1. Use AI to do the mechanical work: format conversions, boilerplate,
+   refactors, lint fixes. Reserve human hours for judgment and design.
+1. When effort is high relative to value, say so and cut it, rather than
+   defending the hours after the fact.
+
+Good: a spec is migrated between formats with AI in minutes, and the reported
+time reflects that. Bad: the same migration is done by hand over hours and
+billed as if the effort were the value.
+
+### Acceptance Criteria
+
+- [ ] Work is assessed by value against cost, not by hours spent
+- [ ] Mechanical, tool-automatable work is not billed as high-effort human work
+- [ ] High-effort, low-value work is flagged and cut rather than justified

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -74,6 +74,7 @@ How to review, and the quality bar work is held to.
 - [DEV-415](./DEV-415.md): re-request review explicitly after addressing changes
 - [DEV-420](./DEV-420.md): scout open PRs when idle
 - [DEV-430](./DEV-430.md): deliver bug-free work; review is a safety check
+- [DEV-440](./DEV-440.md): judge work by value delivered, not effort spent
 
 ## Rule file format
 


### PR DESCRIPTION
## Problem

- Closes #126

Work is justified by hours spent rather than value delivered, so mechanical tasks a tool does in minutes still bill full cost. Reviewers had no rule to cite when rejecting high-effort, low-value work.

## Solution

Adds DEV-440 in the Review category: work is judged by value against cost, not effort, and mechanical work is directed to AI. Indexed in the rules README.
