### PR TITLE
docs: know that AI tooling is a self-borne expense

### DIFF
--- a/docs/EXPENSES.md
+++ b/docs/EXPENSES.md
@@ -30,3 +30,15 @@ travel, conference fees, lodging — when directly tied to your work at Holdex a
 pre-approved by your manager.
 
 Expenses incurred without prior written approval will not be reimbursed.
+
+## What does not qualify
+
+AI tooling (Claude, ChatGPT, Copilot, and similar) is not reimbursable. A paid
+AI plan is a basic cost of doing the work, on the same footing as your internet
+connection, electricity, or a desk and chair. You bear it yourself.
+
+The value of an AI plan depends on how you use it: two people on the same plan
+can burn through credits in a day or stay inside the standard monthly range.
+Sponsoring credits would pay for inefficiency rather than fix it. The way to run
+out less often is to get better at using the tool, not to get a bigger
+allowance.


### PR DESCRIPTION
## Problem

- Closes #128

The policy lists software subscriptions as reimbursable, so contributors ask to have AI tooling sponsored. AI plans are a basic self-borne cost, but nothing written said so.

## Solution

Adds a "What does not qualify" section to EXPENSES.md: AI tooling (Claude, ChatGPT, Copilot, and similar) is not reimbursable and is borne by the individual, on the same footing as internet, electricity, or a desk and chair.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance clarifying that AI tools and plans are not eligible for reimbursement.
  * Explained that additional AI credits beyond standard usage are considered ordinary work-related costs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->