### PR TITLE
docs(rules): take the highest ranked Goal your lead gives you

### DIFF
--- a/docs/rules/DEV-110.md
+++ b/docs/rules/DEV-110.md
@@ -15,8 +15,12 @@ Effort is unanchored, and no one can tell what it is meant to achieve.
 
 Every contribution begins from a Goal issue, with a clear owner.
 
-1. Find a Goal by filtering the repo's issues for the `Goal:` prefix. Prioritize
-   by impact and urgency; consult your lead if unsure which to take.
+1. Where your lead gives you a ranked order of your Goals, take the highest one
+   still open. That order decides what you work on next; do not re-rank it, and
+   raise it with your lead when it is unclear or cannot be met.
+1. Otherwise find a Goal by filtering the repo's issues for the `Goal:` prefix,
+   prioritize by impact and urgency, and consult your lead if unsure which to
+   take.
 1. Assign yourself, or get assigned, so ownership is unambiguous.
 
 A Goal follows the pattern `Goal: [statement]` and must link a Spec; a Goal is


### PR DESCRIPTION
DEV-110 told contributors to pick a Goal by their own read of impact and urgency, and to ask their lead if unsure. For anyone working across several repos that is a guess, and it ignores that a lead may already have decided the order.

The rule now takes the ranked order as the answer where one is given, and keeps the impact-and-urgency fallback for contributors who have none. It says nothing about where that order is kept, which is deliberate: that is the lead's business, not the contribution model's.