### PR TITLE
docs(rules): file a Problem only when work is actually blocked

### DIFF
--- a/docs/rules/DEV-160.md
+++ b/docs/rules/DEV-160.md
@@ -10,8 +10,8 @@ depends_on: ["DEV-150"]
 ## Problem
 
 A Problem titled "missing balance API" or "pinned post needs upgrade" tells a
-stakeholder nothing about what a user cannot do. It cannot be prioritized, no
-one can tell when it is resolved, and routine work filed this way only ages.
+stakeholder nothing about what a user cannot do. Neither names the user or
+business outcome being blocked, so neither can be prioritized.
 
 ## Solution
 
@@ -37,10 +37,11 @@ Bad:   Problem: CSV export missing          (no actor, no action)
 Bad:   Problem: pinned post needs upgrade   (routine work, not a barrier)
 ```
 
-Filing routine acts as Problems micro-chunks the work. Each one adds an issue to
-track, a notification on every PR that touches it, and a status nobody updates,
-while tracking nothing that was ever blocked. Three open issues asking for a
-pinned post to be swapped are not three barriers; they are one unperformed task.
+Filing routine work as Problems splits the work into micro-chunks. Each one adds
+an issue to track, a notification on every PR that touches it, and a status
+nobody updates, while tracking nothing that was ever blocked. Three open issues
+asking for a pinned post to be swapped are not three barriers; they are one
+unperformed task.
 
 ### Acceptance Criteria
 

--- a/docs/rules/DEV-160.md
+++ b/docs/rules/DEV-160.md
@@ -9,14 +9,20 @@ depends_on: ["DEV-150"]
 
 ## Problem
 
-A Problem titled "missing balance API" or "CSV export missing" tells a
-stakeholder nothing about what a user cannot do. It cannot be prioritized, and
-no one can tell when it is resolved.
+A Problem titled "missing balance API" or "pinned post needs upgrade" tells a
+stakeholder nothing about what a user cannot do. It cannot be prioritized, no
+one can tell when it is resolved, and routine work filed this way only ages.
 
 ## Solution
 
-Write each Problem so a non-technical stakeholder understands it at a glance.
+Write each Problem so a non-technical stakeholder understands it at a glance. If
+you cannot state an inability, there is nothing to file: routine work an
+experienced person would simply do is process, not a barrier, and belongs in the
+work itself.
 
+1. Confirm it is a barrier. Ask whether the goal is blocked until someone
+   decides or builds something. If an experienced doer would just do it as part
+   of the work, do it instead of filing it.
 1. Title it `Problem: [statement]`, under 65 characters.
 1. State what the user or business cannot do, in plain terms, not the solution's
    technicalities.
@@ -28,11 +34,19 @@ Write each Problem so a non-technical stakeholder understands it at a glance.
 Good:  Problem: operators can't view their account balance
 Bad:   Problem: missing balance API        (a technicality, not a user problem)
 Bad:   Problem: CSV export missing          (no actor, no action)
+Bad:   Problem: pinned post needs upgrade   (routine work, not a barrier)
 ```
+
+Filing routine acts as Problems micro-chunks the work. Each one adds an issue to
+track, a notification on every PR that touches it, and a status nobody updates,
+while tracking nothing that was ever blocked. Three open issues asking for a
+pinned post to be swapped are not three barriers; they are one unperformed task.
 
 ### Acceptance Criteria
 
 - [ ] The title is `Problem: ...`, under 65 characters
+- [ ] It names a barrier that blocks the goal, not routine work a doer would
+  simply perform
 - [ ] It states a user or business inability, not a solution technicality
 - [ ] A non-technical stakeholder can understand it
 - [ ] It is a sub-issue of the Goal and has a Problem and a Solution section


### PR DESCRIPTION
DEV-160 tells you how to write a Problem statement but never says what does not deserve to be one. So routine work gets filed as Problems, and each one adds an issue to track, a notification on every PR that touches it, and a status nobody updates, while tracking nothing that was ever blocked.

This adds the qualification test to DEV-160 rather than opening a new rule. A clear Problem statement already implies the thing is worth stating as a Problem: if you cannot name an inability, there is nothing to file. Same claim, checkable pass or fail on one subject, so DEV-010's split test does not apply.

What changes:

- A first step in the Solution: confirm the goal is blocked until someone decides or builds something, and if an experienced doer would just do it as part of the work, do it instead of filing it.
- A fourth bad example, `Problem: pinned post needs upgrade`, alongside the existing technicality and no-actor cases.
- A short paragraph on why micro-chunking costs more than it tracks.
- A matching acceptance criterion.

The Problem statement was trimmed to stay inside DEV-050's 250-character cap, which the rules audit enforces on push.

This came out of a cleanup in holdex/marketing, where one Goal had 23 open sub-issues and 12 of them were routine acts. Three separate open issues asked for the same pinned post to be swapped; one had its Solution checkbox already ticked and had been open since March 2025.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Problem-writing guidance to distinguish genuine user or business barriers from routine work.
  * Added barrier-validation criteria and clarified that routine upgrades, such as pinned-post changes, are not valid Problems.
  * Acceptance criteria now require evidence that a goal-blocking barrier exists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->