### PR TITLE
chore(rules): adopt the audit without rewriting existing rules

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -71,16 +71,19 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
   # rule, still triggers the audit and cannot silently break a dependency or
   # index link.
   #
-  # The changed rule files are passed as arguments. The script checks the
+  # The changed rule files are passed after --rules. The script checks the
   # authoring standard of an individual rule only for the rules named there, so a
   # push is blocked by the rules it touches, never by pre-existing ones it does
-  # not. Rules are brought up to standard as they are edited.
+  # not. Rules are brought up to standard as they are edited. The flag is always
+  # passed, even when the list is empty: without it the script runs a full audit,
+  # so a push that changes a doc but no rule would be blocked by every
+  # pre-existing rule in the tree.
   docs_changed=$(git diff --name-only "$base" "$local_sha" -- 'docs/' 'README.md' 2>/dev/null || true)
   if [ -n "$docs_changed" ]; then
     changed_rules=$(git diff --name-only --diff-filter=ACMR "$base" "$local_sha" -- 'docs/rules/*.md' 2>/dev/null || true)
     # Unquoted on purpose: the newline-separated list becomes one argument per
     # rule file. Paths in this repo have no spaces.
-    node "$ROOT/scripts/check-rules.mjs" $changed_rules
+    node "$ROOT/scripts/check-rules.mjs" --rules $changed_rules
   fi
 done
 

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -63,15 +63,24 @@ while IFS=' ' read -r local_ref local_sha remote_ref remote_sha; do
     fi
   fi
 
-  # When any doc changed, audit the rules system and the docs tree. The checks
-  # are holistic (cross-file: id-to-filename, dependency resolution, index
-  # completeness, and reachability from the root README), so a change to one
-  # file can orphan or break an invariant in another. Query git directly (not the
-  # ACMR-filtered $files) so a deletion — e.g. removing a rule — still triggers
-  # the audit and cannot silently break a dependency or index link.
+  # When any doc changed, audit the rules system and the docs tree. The system
+  # checks are holistic (cross-file: dependency resolution, index completeness,
+  # and reachability from the root README), so a change to one file can orphan or
+  # break an invariant in another, and they always run over the whole tree. Query
+  # git directly (not the ACMR-filtered $files) so a deletion, e.g. removing a
+  # rule, still triggers the audit and cannot silently break a dependency or
+  # index link.
+  #
+  # The changed rule files are passed as arguments. The script checks the
+  # authoring standard of an individual rule only for the rules named there, so a
+  # push is blocked by the rules it touches, never by pre-existing ones it does
+  # not. Rules are brought up to standard as they are edited.
   docs_changed=$(git diff --name-only "$base" "$local_sha" -- 'docs/' 'README.md' 2>/dev/null || true)
   if [ -n "$docs_changed" ]; then
-    node "$ROOT/scripts/check-rules.mjs"
+    changed_rules=$(git diff --name-only --diff-filter=ACMR "$base" "$local_sha" -- 'docs/rules/*.md' 2>/dev/null || true)
+    # Unquoted on purpose: the newline-separated list becomes one argument per
+    # rule file. Paths in this repo have no spaces.
+    node "$ROOT/scripts/check-rules.mjs" $changed_rules
   fi
 done
 

--- a/.github/workflows/rules_audit.yml
+++ b/.github/workflows/rules_audit.yml
@@ -1,0 +1,50 @@
+name: Audit Rules
+
+# The pre-push hook runs the same audit, but a hook can be skipped with
+# --no-verify and is not installed on every machine a branch is pushed from.
+# This is the check that cannot be bypassed.
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "README.md"
+      - "scripts/check-rules.mjs"
+      - "rules.config.yml"
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+jobs:
+  audit:
+    # Drafts are work in progress; a rule is expected to be half written there.
+    # The audit starts mattering when the PR is ready for review, and the
+    # ready_for_review event above runs it the moment it is marked ready.
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Both sides of the comparison are needed to list the changed rules.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Audit the rules system
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Mirror the pre-push hook: system invariants across the whole tree,
+          # the authoring standard only on the rules this PR touches. --rules is
+          # always passed, empty list included, because without it the script
+          # runs a full audit and a docs-only PR would fail on every rule that
+          # predates the audit.
+          changed_rules=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- 'docs/rules/*.md')
+          node scripts/check-rules.mjs --rules $changed_rules

--- a/.github/workflows/rules_audit.yml
+++ b/.github/workflows/rules_audit.yml
@@ -38,13 +38,18 @@ jobs:
 
       - name: Audit the rules system
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
+          # Compare against the merge base, not the base branch tip. A plain
+          # two-dot diff against the tip reports every file the base branch
+          # moved on since this PR forked, which would pull rules the PR never
+          # touched into scope and fail it on somebody else's work.
+          base=$(git merge-base "origin/$BASE_REF" HEAD)
+
           # Mirror the pre-push hook: system invariants across the whole tree,
           # the authoring standard only on the rules this PR touches. --rules is
           # always passed, empty list included, because without it the script
           # runs a full audit and a docs-only PR would fail on every rule that
           # predates the audit.
-          changed_rules=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- 'docs/rules/*.md')
+          changed_rules=$(git diff --name-only --diff-filter=ACMR "$base" HEAD -- 'docs/rules/*.md')
           node scripts/check-rules.mjs --rules $changed_rules

--- a/scripts/check-rules.mjs
+++ b/scripts/check-rules.mjs
@@ -17,11 +17,15 @@
 //
 //   The authoring standard for an individual rule (frontmatter, heading
 //   structure, Problem length, writing conventions) runs only on the rule files
-//   passed as arguments, i.e. the ones a push actually touches. A repo adopting
-//   the audit part-way through its life would otherwise be blocked by every
-//   pre-existing rule it did not write today. Rules are brought up to standard
-//   as they are edited. With no arguments every rule is in scope, which is the
-//   full audit for CI or a manual `npm run check:rules`.
+//   listed after `--rules`, i.e. the ones a push actually touches. A repo
+//   adopting the audit part-way through its life would otherwise be blocked by
+//   every pre-existing rule it did not write today. Rules are brought up to
+//   standard as they are edited.
+//
+// Without `--rules` every rule is in scope, which is the full audit for CI or a
+// manual `npm run check:rules`. The flag is what carries the scope, not the
+// presence of arguments: a push that changes a doc but no rule passes
+// `--rules` with nothing after it, and must not silently become a full audit.
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
@@ -44,12 +48,13 @@ const files = readdirSync(RULES_DIR)
   .filter((f) => new RegExp(`^${P}-\\d+\\.md$`).test(f))
   .sort();
 
-// Rule files whose authoring standard is in scope: the ones named on the command
-// line (any path is accepted; only rule files matter here), or all of them when
-// none are named. Every rule is still read below, because the system invariants
+// Rule files whose authoring standard is in scope: everything after `--rules`
+// (any path is accepted; only rule files matter here), or all of them when the
+// flag is absent. Every rule is still read below, because the system invariants
 // need the whole set.
-const named = process.argv.slice(2).map((a) => basename(a));
-const inScope = (file) => named.length === 0 || named.includes(file);
+const flag = process.argv.indexOf("--rules");
+const named = flag === -1 ? null : process.argv.slice(flag + 1).map((a) => basename(a));
+const inScope = (file) => named === null || named.includes(file);
 
 const ids = new Map(); // id -> filename
 const deps = new Map(); // id -> [ids]
@@ -226,7 +231,7 @@ if (errors.length) {
 }
 const scoped = files.filter(inScope).length;
 console.log(
-  scoped === files.length
+  named === null
     ? `Rules audit passed: ${files.length} rules, no issues.`
     : `Rules audit passed: system invariants across ${files.length} rules, ` +
       `authoring standard on the ${scoped} changed, no issues.`,

--- a/scripts/check-rules.mjs
+++ b/scripts/check-rules.mjs
@@ -7,6 +7,21 @@
 // review. Exits non-zero (listing every failure) if any rule breaks structure,
 // frontmatter, linking, or index invariants, or a doc is orphaned, so the
 // pre-push hook can block the push. Run directly with `npm run check:rules`.
+//
+// Two scopes, deliberately different:
+//
+//   System invariants (dependency resolution and cycles, prose link targets,
+//   index completeness, docs reachability, root README) always run across the
+//   whole tree. They are cross-file by nature: a change to one file can orphan
+//   or break another, so checking only what changed would miss the breakage.
+//
+//   The authoring standard for an individual rule (frontmatter, heading
+//   structure, Problem length, writing conventions) runs only on the rule files
+//   passed as arguments, i.e. the ones a push actually touches. A repo adopting
+//   the audit part-way through its life would otherwise be blocked by every
+//   pre-existing rule it did not write today. Rules are brought up to standard
+//   as they are edited. With no arguments every rule is in scope, which is the
+//   full audit for CI or a manual `npm run check:rules`.
 
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
@@ -29,6 +44,13 @@ const files = readdirSync(RULES_DIR)
   .filter((f) => new RegExp(`^${P}-\\d+\\.md$`).test(f))
   .sort();
 
+// Rule files whose authoring standard is in scope: the ones named on the command
+// line (any path is accepted; only rule files matter here), or all of them when
+// none are named. Every rule is still read below, because the system invariants
+// need the whole set.
+const named = process.argv.slice(2).map((a) => basename(a));
+const inScope = (file) => named.length === 0 || named.includes(file);
+
 const ids = new Map(); // id -> filename
 const deps = new Map(); // id -> [ids]
 
@@ -39,19 +61,19 @@ for (const file of files) {
   const text = readFileSync(join(RULES_DIR, file), "utf8");
   const fmMatch = text.match(/^---\n([\s\S]*?)\n---/);
   if (!fmMatch) {
-    fail(ref, "missing frontmatter block");
+    if (inScope(file)) fail(ref, "missing frontmatter block");
     continue;
   }
   const fm = fmMatch[1];
 
   const idMatch = fm.match(new RegExp(`^id:\\s*(${P}-\\d+)\\s*$`, "m"));
   if (!idMatch) {
-    fail(ref, "frontmatter has no id");
+    if (inScope(file)) fail(ref, "frontmatter has no id");
     continue;
   }
   const id = idMatch[1];
   const base = file.replace(/\.md$/, "");
-  if (id !== base) fail(ref, `id ${id} does not match filename`);
+  if (id !== base && inScope(file)) fail(ref, `id ${id} does not match filename`);
   ids.set(id, ref);
 
   const depMatch = fm.match(/^depends_on:\s*\[(.*?)\]\s*$/m);
@@ -64,6 +86,10 @@ for (const file of files) {
           .filter(Boolean)
       : [],
   );
+
+  // Everything below is the authoring standard for this one rule, so it applies
+  // only when the rule itself is in scope.
+  if (!inScope(file)) continue;
 
   // DEV-020: body opens Problem, Solution, then nested Acceptance Criteria.
   if (!/^## Problem$/m.test(text)) fail(ref, "missing `## Problem`");
@@ -198,4 +224,10 @@ if (errors.length) {
   for (const e of errors) console.error(`  - ${e}`);
   process.exit(1);
 }
-console.log(`Rules audit passed: ${files.length} rules, no issues.`);
+const scoped = files.filter(inScope).length;
+console.log(
+  scoped === files.length
+    ? `Rules audit passed: ${files.length} rules, no issues.`
+    : `Rules audit passed: system invariants across ${files.length} rules, ` +
+      `authoring standard on the ${scoped} changed, no issues.`,
+);


### PR DESCRIPTION
# Problem

A repo that has been writing rules for months cannot adopt the audit. It checks
the authoring standard of every rule in the tree, so the first push after wiring
the hook fails on every rule written before the audit existed, and blocks all
work until the back catalogue is rewritten in one sitting. holdex/partnerships
reports 157 failures across 31 rules on first run.

# Solution

Splits the checks by scope.

**System invariants run over the whole tree, always**: dependency resolution and
cycles, prose link targets, index completeness, docs reachability, the root
README. They are cross-file, so scoping them would miss the breakage they exist
to catch. Renaming one rule can orphan another.

**The authoring standard of an individual rule runs only on the rule files
listed after `--rules`**: frontmatter, heading structure, Problem length, no
em/en dashes. The pre-push hook passes the rules the push touches. Without the
flag every rule is in scope, so `npm run check:rules` and CI stay a full audit.

The flag carries the scope, not the presence of arguments. A push that changes a
doc but no rule passes `--rules` with an empty list and is checked for system
invariants only. Deriving scope from "were any arguments given" would make that
push a full audit, which in an adopting repo means blocked on every pre-existing
rule.

A push is then blocked by the rules it touches and never by pre-existing ones,
and rules come up to standard as they are edited.

The success line reports which scope ran, so a scoped pass never reads as a full
audit.

Also adds `.github/workflows/rules_audit.yml`, so the audit is not hook-only: a
hook can be skipped with `--no-verify` and is not installed on every machine a
branch is pushed from. It runs the same two scopes and skips drafts, starting at
`ready_for_review`.

The workflow scopes against the merge base, not the base branch tip. A two-dot
diff against the tip reports every file `main` moved on since the PR forked,
which would pull rules the PR never touched into scope and fail it on somebody
else's work.

# Verification

In this repo, where every rule already meets the standard, behaviour is
unchanged:

- `npm run check:rules` passes: 35 rules, no issues.
- Scoped to one file: "system invariants across 35 rules, authoring standard on
  the 1 changed, no issues."
- Breaking `DEV-050`'s Problem heading and scoping to `DEV-020` passes; scoping
  to `DEV-050` fails with exit 1.
- `--rules` with an empty list: system invariants only, 0 rules in scope.
- The merge-base scoping was checked against the tip-diff it replaces, on a
  branch that changed one rule while `main` had migrated another: the tip diff
  reports both rules, the merge-base diff reports only the one the branch
  touched.

# Notes for the reviewer

- This is the shared script, so the same commit is going into holdex/partnerships:
  - https://github.com/holdex/partnerships/pull/78
- Adoption there is the reason this exists. Two heading shapes will coexist in
  that repo while its 30 remaining rules migrate as they are edited, which is
  the deliberate trade against a 31-file rewrite nobody can review.

# Related to

- Closes #138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated rule auditing for pull requests targeting the main branch.
  - Audits now focus authoring-standard checks on changed rule documents while continuing to validate overall rule integrity.
  - Added support for running either complete audits or scoped checks.

- **Bug Fixes**
  - Improved pre-push validation to avoid unnecessary checks while preserving comprehensive documentation and dependency audits.
  - Deleted rule documents continue to trigger full integrity validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->