### PR TITLE
docs(rules): find every user type and its actions in a Spec

### DIFF
--- a/docs/rules/DEV-125.md
+++ b/docs/rules/DEV-125.md
@@ -23,6 +23,15 @@ about what users can do, not how the system works.
    [DEV-180](./DEV-180.md).
 1. Start with `goal:` frontmatter linking the Goal, then an H1 feature name and
    a `## Overview` of what the Goal enables for users.
+1. List every user type in `## User Types`, including operator and administrator
+   types that are not the client's end-users. If a type's account is provisioned
+   outside the product (database seed, manual setup), say so, and say whether
+   the product can create more of them.
+1. Treat the user account as a key concept, not as a separate administration
+   area: creating, listing, granting access to, and removing accounts are
+   actions on it like any other.
+1. Name the permitted user type in every action. An action with an implicit
+   actor cannot be reviewed against what the product actually allows.
 1. Add author-defined `##` sections that describe observable user behavior, not
    internal mechanics.
 1. Include a `## Design` section using the markup in [DEV-350](./DEV-350.md)
@@ -42,12 +51,17 @@ goal: <link to Goal issue>
 (three items; max 160 chars each)
 
 ## User Types
-(list of end-users' types and their short definition; each item max 150 chars)
+(list of every user type and its short definition, operators and
+administrators included; each item max 150 chars. Note any type whose
+account is provisioned outside the product, and whether more can be
+created in the product)
 
 ## Key Concepts
 
 (subsections describing key concepts end-user needs to know about;
-the relevant methods (actions) specific users can use)
+the relevant methods (actions) specific users can use. Include the user
+account itself as a concept, with its create, list, access, and remove
+actions. Name the permitted user type in every action)
 
 ## [Section]
 
@@ -58,5 +72,9 @@ Describe what users can do, not how the system works internally.
 
 - [ ] The Spec is a `docs/specs/` file with `goal:` frontmatter, an H1 name, and
   a `## Overview`
+- [ ] `## User Types` covers every type, operators and administrators included,
+  and states how any externally provisioned account comes into existence
+- [ ] The user account appears in `## Key Concepts` with its own actions
+- [ ] Every action names the user types permitted to perform it
 - [ ] Sections describe user-observable behavior, not internal mechanics
 - [ ] A Goal with a design component includes a `## Design` section per DEV-350

--- a/docs/rules/DEV-125.md
+++ b/docs/rules/DEV-125.md
@@ -58,10 +58,10 @@ created in the product)
 
 ## Key Concepts
 
-(subsections describing key concepts end-user needs to know about;
-the relevant methods (actions) specific users can use. Include the user
-account itself as a concept, with its create, list, access, and remove
-actions. Name the permitted user type in every action)
+(subsections describing key concepts users need to know about; the
+relevant methods (actions) each permitted user type can use. Include the
+user account itself as a concept, with its create, list, access, and
+remove actions. Name the permitted user types in every action)
 
 ## [Section]
 
@@ -73,7 +73,8 @@ Describe what users can do, not how the system works internally.
 - [ ] The Spec is a `docs/specs/` file with `goal:` frontmatter, an H1 name, and
   a `## Overview`
 - [ ] `## User Types` covers every type, operators and administrators included,
-  and states how any externally provisioned account comes into existence
+      states how any externally provisioned account comes into existence, and
+      says whether the product can create more of that type
 - [ ] The user account appears in `## Key Concepts` with its own actions
 - [ ] Every action names the user types permitted to perform it
 - [ ] Sections describe user-observable behavior, not internal mechanics


### PR DESCRIPTION
DEV-125 asks for `## User Types` and `## Key Concepts`, but says nothing about what belongs in them. In practice this leaves gaps: a spec lists the client-facing user types and omits the operator or administrator ones, the account that creates all the others goes undocumented because it is seeded rather than created in the app, and actions get written without naming who is allowed to perform them, so a reviewer cannot check the spec against what the product actually permits.

This surfaced while documenting the Curia Regis user docs, where the System Administrator, the account that creates consultants and onboards companies, appeared nowhere.

## What changed

`docs/rules/DEV-125.md` only:

- Three new Solution steps: cover every user type including operators and administrators, say how an externally provisioned account comes into existence, treat the user account as a key concept rather than a separate administration area, and name the permitted user type in every action.
- The template block's `## User Types` and `## Key Concepts` guidance updated to match.
- Three matching acceptance criteria.

## For the reviewer

No other rule changes. One pre-existing inconsistency left untouched: the Solution and acceptance criteria call for `## Overview`, while the template block has `## Objective` and `## Key results`. Worth a separate fix if you agree it is a mismatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the specification template to require comprehensive user-type definitions, including operators and administrators.
  * Added guidance for externally provisioned accounts and product-supported account creation.
  * Documented user-account actions such as creating, listing, accessing, and removing accounts.
  * Added acceptance criteria requiring permissions to be identified for each action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->