### PR TITLE
docs(advocacy): tag the CEO on Bluesky

### DIFF
--- a/docs/ADVOCACY.md
+++ b/docs/ADVOCACY.md
@@ -49,4 +49,4 @@ mandatory description:
 
 Engage actively: Share Holdex news/updates, interact with our community, respond
 to comments/questions, and tag [@holdexio](https://x.com/holdex.io) and
-[@zolotokrylin](https://bsky.app/profile/zolotokrylin.bsky.social)
+[@zolotokrylin on Bluesky](https://bsky.app/profile/zolotokrylin.bsky.social)

--- a/docs/ADVOCACY.md
+++ b/docs/ADVOCACY.md
@@ -49,4 +49,4 @@ mandatory description:
 
 Engage actively: Share Holdex news/updates, interact with our community, respond
 to comments/questions, and tag [@holdexio](https://x.com/holdex.io) and
-[@zolotokrylin](https://x.com/zolotokrylin)
+[@zolotokrylin](https://bsky.app/profile/zolotokrylin.bsky.social)


### PR DESCRIPTION
The link to the CEO's X profile now points at his Bluesky profile,
<https://bsky.app/profile/zolotokrylin.bsky.social>.

The handle resolves to `did:plc:2qkdph5lljtmrrnuhyu46rr7`, and the page
returns 200.

Where the link text named the platform, it now names Bluesky, so the label and
the destination agree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated advocacy guidance to link to the specified Bluesky profile instead of the previous X profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->