### PR TITLE
docs(rules): tell a shipped spec from a plan not yet built

### DIFF
--- a/docs/rules/DEV-180.md
+++ b/docs/rules/DEV-180.md
@@ -9,29 +9,40 @@ depends_on: ["DEV-110", "DEV-170"]
 
 ## Problem
 
-When a Spec describes behavior that already shipped, or `docs/product/`
-describes behavior that was never built, a reader cannot tell what the product
-actually does today. The backlog and the documentation rot into fiction.
+A spec that stays behind after its behavior ships is indistinguishable from one
+that is still a plan. Readers take shipped work for unbuilt, and the stale text
+collides with the next spec written for the same feature.
 
 ## Solution
 
-Split intended behavior from shipped behavior, and move sections across as work
-lands.
+Keep one source of truth for what the product does, and a separate one for what
+stakeholders still want. The product is the app together with its end-user docs.
+The spec is the plan, and holds only what is not built yet.
 
-1. `docs/specs/<feature>.md` holds only unimplemented behavior for a Goal.
-   `docs/product/<feature>.md` holds only what currently ships.
-1. Each PR that delivers behavior moves the corresponding sections out of the
-   spec and into the appropriate file under `docs/product/`. A spec may graduate
-   into more than one `docs/product/` file.
-1. When scope is added after the Spec merges, open a new PR against the spec
+A spec states what the business needs before anyone builds it. The product docs
+are part of the product, not a description of it: they carry what a user cannot
+work out from the screen alone. Once behavior ships it stops being a proposal
+and becomes a fact in the source code, so it leaves the spec. What a user still
+needs in order to use it moves to the product docs. What the UI already makes
+obvious goes nowhere, because a field visible on the screen documents itself.
+
+1. `docs/specs/<feature>.md` holds only unimplemented behavior for a Goal. The
+   product docs hold only what ships today: `docs/product/<feature>.md` by
+   default, or the path the repo's docs README declares where it differs.
+1. Each PR that delivers behavior moves the delivered sections out of the spec.
+   Graduate what a user cannot infer from the UI, drop the rest. A spec may
+   graduate into more than one file.
+1. When scope is added after the spec merges, open a new PR against the spec
    file and create Problem issues for the added scope.
-1. When every section has graduated, keep the spec file as frontmatter only.
-   Never delete it, so the Goal's `# Spec` link keeps working.
+1. When every section has graduated or been dropped, keep the spec file as
+   frontmatter only. Never delete it, so the Goal's `# Spec` link keeps working.
+1. Do not close a Goal while its spec still holds behavior that shipped.
 
 ### Acceptance Criteria
 
 - [ ] `docs/specs/` holds only unimplemented behavior
-- [ ] `docs/product/` holds only shipped behavior
-- [ ] Each shipping PR graduates the delivered sections from spec to
-  `docs/product/`
+- [ ] The product docs hold only shipped behavior, and only what the UI does not
+      make obvious
+- [ ] Each shipping PR graduates or drops the delivered sections
 - [ ] A fully graduated spec file is kept as frontmatter only, not deleted
+- [ ] No Goal is closed while its spec still describes shipped behavior


### PR DESCRIPTION
DEV-180 said to move spec sections into the product docs, but never said why, so the step read as filing work and got skipped on the way to closing a Goal. It now opens with the reason: the product (the app and its end-user docs) is the one source of truth for what exists, and the spec is the one source of truth for what stakeholders still want.

The Problem now names the cost that actually bites. A spec left behind after its behavior ships is indistinguishable from a plan, so readers take shipped work for unbuilt, and the stale text collides with the next spec written for the same feature.

The Solution gains the judgement call that was missing. Product docs are part of the product, carrying what a user cannot work out from the screen alone, so a delivered section graduates only when the UI does not already make it obvious. Everything else is dropped rather than copied, which keeps the docs from bloating into a restatement of the interface.

Two mechanical gaps close with it. The product docs path stays `docs/product/` by default and allows a repo to declare its own, and a Goal can no longer be closed while its spec still describes shipped behavior, which is the point where this was being missed.

Both changes are checkable, and the audit and markdown lint pass.

- https://github.com/Curia-Regis/app/issues/305
- https://github.com/Curia-Regis/app/issues/303


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how product documentation and specifications serve as separate sources of truth.
  * Added guidance for moving shipped behavior into product documentation while retaining only unfinished work in specifications.
  * Defined documentation locations, handling for expanded scope, and rules for preserving completed specifications.
  * Updated acceptance criteria to ensure documentation reflects shipped behavior without duplicating what the interface makes obvious.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->